### PR TITLE
Allow compiling for c++11

### DIFF
--- a/packages/gpu_voxels/src/gpu_voxels/helpers/cuda_handling.hpp
+++ b/packages/gpu_voxels/src/gpu_voxels/helpers/cuda_handling.hpp
@@ -122,8 +122,8 @@ cudaError_t cuPrintDeviceArray(T* dev_array, unsigned int* device_array_size)
   for (unsigned int i = 0; i < array_size; i++)
   {
     std::stringstream s;
-    s << i << ": " << host_array[i];
-    LOGGING_INFO(Gpu_voxels_helpers, s << endl);
+    s << i << ": " << host_array[i] << endl;
+    LOGGING_INFO(Gpu_voxels_helpers, s.str());
   }
   LOGGING_INFO(Gpu_voxels_helpers, endl);
   delete[] host_array;


### PR DESCRIPTION
I was not able to compile gpu-voxels as a library for c++11 due to implicit cast from stringstream to string.
With this change, c++11 compilation succeeds.


Error:
/home/bradsaund/gvl/include/gpu_voxels/helpers/cuda_handling.hpp: In function ‘cudaError_t gpu_voxels::cuPrintDeviceArray(T*, unsigned int*)’:
/home/bradsaund/gvl/include/icl_core_logging/LoggingMacros_SLOGGING.h:69:23: error: no match for ‘operator<<’ (operand types are ‘icl_core::logging::ThreadStream’ and ‘std::stringstream {aka std::__cxx11::basic_stringstream<char>}’)
         thread_stream << arg; 

