### PR TITLE
fix compilation error

### DIFF
--- a/packages/gpu_voxels/src/gpu_visualization/Visualizer.cu
+++ b/packages/gpu_voxels/src/gpu_visualization/Visualizer.cu
@@ -1840,8 +1840,8 @@ void Visualizer::move_slice_axis(int offset) {
 
 void Visualizer::keyboardFunction(unsigned char key, int32_t x, int32_t y)
 {
-  static int8_t decimal_prefix(0);
-  static int8_t decimal_key(0);
+  static glm::int8_t decimal_prefix(0);
+  static glm::int8_t decimal_key(0);
 
   float multiplier = 1.f;
   if (glutGetModifiers() == GLUT_ACTIVE_SHIFT)
@@ -1853,7 +1853,7 @@ void Visualizer::keyboardFunction(unsigned char key, int32_t x, int32_t y)
     multiplier *= 10.f;
   }
 
-  int8_t modi = glutGetModifiers();
+  glm::int8_t modi = glutGetModifiers();
   bool alt_pressed = modi & GLUT_ACTIVE_ALT;
   printf("Keycode: %c, Modifier value: %d, alt_pressed=%u\n", key, modi, alt_pressed);
 
@@ -2106,7 +2106,7 @@ void Visualizer::lastKeyboardMode()
   LOGGING_INFO_C(Visualization, Visualizer, "Keyboardmode set to " << keyboardModetoString(m_keyboardmode) << endl);
 }
 
-void Visualizer::keyboardFlipVisibility(int8_t index)
+void Visualizer::keyboardFlipVisibility(glm::int8_t index)
 {
   switch (m_keyboardmode)
   {
@@ -2126,7 +2126,7 @@ void Visualizer::keyboardFlipVisibility(int8_t index)
       break;
   }
 }
-std::string Visualizer::keyboardModetoString(int8_t index)
+std::string Visualizer::keyboardModetoString(glm::int8_t index)
 {
   switch (index)
   {

--- a/packages/gpu_voxels/src/gpu_visualization/Visualizer.h
+++ b/packages/gpu_voxels/src/gpu_visualization/Visualizer.h
@@ -339,7 +339,7 @@ private:
   void keyboardFlipVisibility(glm::int8_t index);
   void nextKeyboardMode();
   void lastKeyboardMode();
-  std::string keyboardModetoString(int8_t index);
+  std::string keyboardModetoString(glm::int8_t index);
   void keyboardDrawTriangles();
 
   /**
@@ -411,7 +411,7 @@ private:
 
   std::vector<Primitive*> m_primitives;
 
-  int8_t m_keyboardmode;
+  glm::int8_t m_keyboardmode;
   u_int8_t m_trianglemode;
 
   //benchmark variables


### PR DESCRIPTION
When I was compiling the gpu-voxels, some compilation errors occur and all of them refer to ambiguous problem in int8_t. In this pull request, I fix these ambiguities by explicitly specify the namespace of int8_t.  

My test environment is Ubuntu 16.04.5 (AMD64).