### PR TITLE
Fix: Add include for compiling with cuda10.1

### DIFF
--- a/packages/gpu_voxels/src/gpu_voxels/voxelmap/DistanceVoxelMap.hpp
+++ b/packages/gpu_voxels/src/gpu_voxels/voxelmap/DistanceVoxelMap.hpp
@@ -41,6 +41,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/tuple.h>
 #include <thrust/transform.h>
+#include <thrust/device_malloc_allocator.h>
 
 #include <gpu_voxels/logging/logging_gpu_voxels.h>
 


### PR DESCRIPTION
Without this `include` I get the following error when compiling with `cuda-10.1`:
`.../gpu_voxels/voxelmap/DistanceVoxelMap.hpp(63): error: namespace "thrust" has no member class "device_malloc_allocator"`


Context:
I have previously been using gpu-voxels with Cuda9.
I noticed this error when upgrading to `cuda-10.1` (Nvidia driver `430.50`).

Without this patch:
10.0: No compilation errors
10.1: Error (see above)

With this patch:
10.0: No compilation errors
10.1: No compilation errors