### PR TITLE
Fixes for CUDA 12.0 on Ubuntu 20.04

### DIFF
--- a/packages/gpu_voxels/CMakeLists.txt
+++ b/packages/gpu_voxels/CMakeLists.txt
@@ -61,7 +61,7 @@ ENDIF(CUDA_FOUND)
 IF(GLEW_FOUND AND GLM_FOUND AND OPENGL_FOUND AND GLUT_FOUND)
   MESSAGE(STATUS "[OK]      Building GPU-Voxels with visualization. GLEW, GLM, OpenGL and GLUT were found.")
 ELSE(GLEW_FOUND AND GLM_FOUND AND OPENGL_FOUND AND GLUT_FOUND)
-  MESSAGE(STATUS "[WARNING] Building GPU-Voxels without visualization because the following packages are missing:") 
+  MESSAGE(STATUS "[WARNING] Building GPU-Voxels without visualization because the following packages are missing:")
   IF(NOT GLEW_FOUND)
     MESSAGE(STATUS "    Glew")
   ENDIF(NOT GLEW_FOUND)
@@ -136,7 +136,7 @@ MESSAGE(STATUS "----------------------------------------------------------------
 # Change these lines to increase performance if your GPU's compute capability is higher
 # GPU-Voxels requires GPU CUDA capabilities >= 2.0
 #SET(ICMAKER_CUDA_COMPUTE_VERSION 20)
-SET(ICMAKER_CUDA_COMPUTE_VERSION 35)
+SET(ICMAKER_CUDA_COMPUTE_VERSION 61)
 
 SET(ICMAKER_CUDA_ARCH compute_${ICMAKER_CUDA_COMPUTE_VERSION})
 SET(ICMAKER_CUDA_CODE compute_${ICMAKER_CUDA_COMPUTE_VERSION})
@@ -144,7 +144,7 @@ SET(ICMAKER_CUDA_CODE compute_${ICMAKER_CUDA_COMPUTE_VERSION})
 #Usage example for specifying PTX for compute_35 and cubin for sm_51:
 # SET(ICMAKER_CUDA_CODE compute_35,sm_51)
 
-## Uncomment this definition if you want to avoid PTX JIT compilation at first runtime. 
+## Uncomment this definition if you want to avoid PTX JIT compilation at first runtime.
 ## Having both a compute_ and a sm_ code target will include both PTX and CUBIN in the final binary.
 ## IMPORTANT: Check your device's compute capability. the sm_xy argument needs to match your device to have any effect!
 ## Version table: https://en.wikipedia.org/wiki/CUDA#GPUs_supported

--- a/packages/gpu_voxels/src/gpu_visualization/Visualizer.cu
+++ b/packages/gpu_voxels/src/gpu_visualization/Visualizer.cu
@@ -1684,7 +1684,7 @@ void Visualizer::renderFunction(void)
   {
     float wait = 1000.f / m_max_fps - m_delta_time;
     m_delta_time += wait;
-    boost::this_thread::sleep(boost::posix_time::milliseconds(wait));
+    boost::this_thread::sleep(boost::posix_time::milliseconds(long(wait)));
   }
 }
 

--- a/packages/gpu_voxels/src/gpu_voxels/octree/NTree.hpp
+++ b/packages/gpu_voxels/src/gpu_voxels/octree/NTree.hpp
@@ -65,10 +65,11 @@ namespace cub = thrust::system::cuda::detail::cub_;
 #else // Cuda 9 or higher
 #define THRUST_CUB_NS_PREFIX namespace thrust {   namespace cuda_cub {
 #define THRUST_CUB_NS_POSTFIX }  }
-#include <thrust/system/cuda/detail/cub/device/device_radix_sort.cuh>
-#undef CUB_NS_PREFIX
-#undef CUB_NS_POSTFIX
-namespace cub = thrust::cuda_cub::cub;
+/* #include <thrust/system/cuda/detail/cub/device/device_radix_sort.cuh> */
+#include <cub/device/device_radix_sort.cuh>
+/* #undef CUB_NS_PREFIX */
+/* #undef CUB_NS_POSTFIX */
+/* namespace cub = thrust::cuda_cub::cub; */
 #endif
 
 // Internal dependencies

--- a/packages/gpu_voxels/src/gpu_voxels/octree/NTreeData.h
+++ b/packages/gpu_voxels/src/gpu_voxels/octree/NTreeData.h
@@ -44,10 +44,11 @@ namespace cub = thrust::system::cuda::detail::cub_;
 #else // Cuda 9 or higher
 #define THRUST_CUB_NS_PREFIX namespace thrust {   namespace cuda_cub {
 #define THRUST_CUB_NS_POSTFIX }  }
-#include <thrust/system/cuda/detail/cub/util_type.cuh>
-#undef CUB_NS_PREFIX
-#undef CUB_NS_POSTFIX
-namespace cub = thrust::cuda_cub::cub;
+/* #include <thrust/system/cuda/detail/cub/util_type.cuh> */
+#include <cub/util_type.cuh>
+/* #undef CUB_NS_PREFIX */
+/* #undef CUB_NS_POSTFIX */
+/* namespace cub = thrust::cuda_cub::cub; */
 #endif
 
 namespace gpu_voxels {

--- a/packages/gpu_voxels/src/gpu_voxels/octree/PointCloud.cu
+++ b/packages/gpu_voxels/src/gpu_voxels/octree/PointCloud.cu
@@ -19,10 +19,11 @@ namespace cub = thrust::system::cuda::detail::cub_;
 #else // Cuda 9 or higher
 #define THRUST_CUB_NS_PREFIX namespace thrust {   namespace cuda_cub {
 #define THRUST_CUB_NS_POSTFIX }   }
-#include <thrust/system/cuda/detail/cub/device/device_radix_sort.cuh>
-#undef CUB_NS_PREFIX
-#undef CUB_NS_POSTFIX
-namespace cub = thrust::cuda_cub::cub;
+/* #include <thrust/system/cuda/detail/cub/device/device_radix_sort.cuh> */
+#include <cub/device/device_radix_sort.cuh>
+/* #undef CUB_NS_PREFIX */
+/* #undef CUB_NS_POSTFIX */
+/* namespace cub = thrust::cuda_cub::cub; */
 #endif
 
 #include <thrust/sort.h>

--- a/packages/gpu_voxels/src/gpu_voxels/octree/kernels/kernel_common.h
+++ b/packages/gpu_voxels/src/gpu_voxels/octree/kernels/kernel_common.h
@@ -43,10 +43,11 @@ namespace cub = thrust::system::cuda::detail::cub_;
 #else // Cuda 9 or higher
 #define THRUST_CUB_NS_PREFIX namespace thrust {   namespace cuda_cub {
 #define THRUST_CUB_NS_POSTFIX }  }
-#include <thrust/system/cuda/detail/cub/util_type.cuh>
-#undef CUB_NS_PREFIX
-#undef CUB_NS_POSTFIX
-namespace cub = thrust::cuda_cub::cub;
+/* #include <thrust/system/cuda/detail/cub/util_type.cuh> */
+#include <cub/util_type.cuh>
+/* #undef CUB_NS_PREFIX */
+/* #undef CUB_NS_POSTFIX */
+/* namespace cub = thrust::cuda_cub::cub; */
 #endif
 
 // __ballot has been replaced by __ballot_sync in Cuda9

--- a/packages/gpu_voxels/src/gpu_voxels/test/testing_thrust.cu
+++ b/packages/gpu_voxels/src/gpu_voxels/test/testing_thrust.cu
@@ -25,6 +25,7 @@
 #include <thrust/binary_search.h>
 #include <thrust/generate.h>
 #include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 #include <thrust/execution_policy.h>
 #include <boost/test/unit_test.hpp>
 #include <gpu_voxels/test/testing_fixtures.hpp>

--- a/packages/gpu_voxels/src/gpu_voxels/voxellist/BitVoxelList.h
+++ b/packages/gpu_voxels/src/gpu_voxels/voxellist/BitVoxelList.h
@@ -24,6 +24,7 @@
 #ifndef GPU_VOXELS_VOXELLIST_BITVOXELLIST_H
 #define GPU_VOXELS_VOXELLIST_BITVOXELLIST_H
 
+#include <thrust/host_vector.h>
 #include <gpu_voxels/voxel/BitVoxel.h>
 #include <gpu_voxels/voxel/SVCollider.h>
 #include <gpu_voxels/voxellist/TemplateVoxelList.h>

--- a/packages/gpu_voxels/src/gpu_voxels/voxellist/TemplateVoxelList.hpp
+++ b/packages/gpu_voxels/src/gpu_voxels/voxellist/TemplateVoxelList.hpp
@@ -37,6 +37,7 @@
 #include <thrust/remove.h>
 #include <thrust/binary_search.h>
 #include <thrust/system_error.h>
+#include <thrust/host_vector.h>
 
 namespace gpu_voxels {
 namespace voxellist {

--- a/packages/gpu_voxels/src/gpu_voxels/voxelmap/DistanceVoxelMap.hpp
+++ b/packages/gpu_voxels/src/gpu_voxels/voxelmap/DistanceVoxelMap.hpp
@@ -34,6 +34,7 @@
 
 #include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 #include <thrust/inner_product.h>
 #include <thrust/fill.h>
 #include <thrust/count.h>


### PR DESCRIPTION
This PR builds on #117 and provides fixes for compiling the library on Ubuntu 20.04 with Cuda 12.0 and higher compute capable machine support. Hopefully this helps someone who might want to work on it in future!