### PR TITLE
Fix octree

### DIFF
--- a/packages/gpu_voxels/src/gpu_voxels/octree/kernels/kernel_common.h
+++ b/packages/gpu_voxels/src/gpu_voxels/octree/kernels/kernel_common.h
@@ -51,9 +51,9 @@ namespace cub = thrust::cuda_cub::cub;
 
 // __ballot has been replaced by __ballot_sync in Cuda9
 #if(__CUDACC_VER_MAJOR__ >= 9)
-#define FULL_MASK 0xffffffff
-#define BALLOT(PREDICATE) __ballot_sync(FULL_MASK, PREDICATE)
-#define ANYWARP(PREDICATE) __any_sync(FULL_MASK, PREDICATE)
+//#define FULL_MASK 0xffffffff
+#define BALLOT(PREDICATE) __ballot_sync(__activemask(), PREDICATE)
+#define ANYWARP(PREDICATE) __any_sync(__activemask(), PREDICATE)
 #else
 #define BALLOT(PREDICATE) __ballot(PREDICATE)
 #define ANYWARP(PREDICATE) __any(PREDICATE)


### PR DESCRIPTION
Fixes wrong assumption of full mask for CUDA >= 9
May have performance implications but makes octree usable again

Related issues and blogposts:
https://github.com/ComputationalRadiationPhysics/picongpu/pull/2629/files
https://forums.developer.nvidia.com/t/ballot-sync-inside-for-loop-causes-kernel-to-hang-in-sm-75/160816

Should fix #105 and #128